### PR TITLE
fixed "impossible" values, populated defaults, WG Open -> crack pressure

### DIFF
--- a/boostController.ino
+++ b/boostController.ino
@@ -186,7 +186,7 @@ void screen(double mapReading) {
     if (mode == 2) {
       display.println("Set Spring Pressure:");
     } else if (mode == 3) {
-      display.println("Set WG Open:");
+      display.println("Set Crack Pressure:");
     } else if (mode == 4) {
       display.println("Set Max Boost:");
     }
@@ -262,10 +262,22 @@ void modeSwitch() {
       }
       if (mode == 2) {
         springPress = value;
+        if (springPress > openEnd) {
+          openEnd = value;
+        }
       } else if (mode == 3) {
         openStart = value;
+        if (openStart > openEnd) {
+          openEnd = openStart;
+        }
       } else if (mode == 4) {
         openEnd = value;
+        if (openEnd < openStart) {
+          openEnd = openStart;
+        }
+        if (openEnd < springPress) {
+          openEnd = springPress;
+        }
       }
       saveValues();
       calculateEXZval();


### PR DESCRIPTION
WG Open changed to "Crack Pressure"
Max Boost cannot be lower than spring pressure or crack pressure Max Boost will "snap" to spring pressure on first set (or crack pressure if it is set higher than spring pressure), setting Max Boost lower than crack pressure or spring pressure will result in it being snapped to the highest value of the 2 when moving to the next setting